### PR TITLE
fix: duplex print not working

### DIFF
--- a/ksicht/core/views/submissions.py
+++ b/ksicht/core/views/submissions.py
@@ -406,14 +406,14 @@ class SolutionExportView(View):
         filename = quote(f"{self.task} - export řešení")
         response["Content-Disposition"] = f"attachment; filename*=UTF-8''{filename}.pdf"
         is_duplex = bool(request.GET.get("duplex"))
-        normalized_solution_files = []
+        solution_files = []
 
         for s in submitted_solutions:
-            normalized_solution_files.append(
-                s.file_for_export_duplex if is_duplex else s.file_for_export_normal
+            solution_files.append(
+                s.file_for_export_normal
             )
 
         # Join all files in one large batch.
-        pdf.concatenate(normalized_solution_files, response)
+        pdf.concatenate(solution_files, response, is_duplex)
 
         return response

--- a/ksicht/pdf.py
+++ b/ksicht/pdf.py
@@ -10,6 +10,7 @@ from pypdf import PdfReader as PdfFileReader, PageObject
 from pypdf import PdfWriter as PdfFileWriter
 from pypdf.errors import PdfReadError
 import reportlab
+from pypdf import PaperSize
 from reportlab.lib.pagesizes import A4, C3, landscape
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.pdfbase import pdfmetrics
@@ -113,10 +114,9 @@ def concatenate(in_files, out_file, as_duplex=False):
 
 
 def get_blank_page():
-    blank_pdf_filename = settings.BLANK_PDF_FILEPATH
-    if not Path(blank_pdf_filename).exists():
+    if not Path(blank_pdf_filename := settings.BLANK_PDF_FILEPATH).exists():
         writer = PdfFileWriter()
-        writer.add_blank_page(width=8.27 * 72, height=11.7 * 72)
+        writer.add_blank_page(width=PaperSize.A4.width, height=PaperSize.A4.height)
         with open(blank_pdf_filename, "wb") as fp:
             writer.write(fp)
             writer.close()
@@ -124,10 +124,8 @@ def get_blank_page():
 
 
 def delete_blank_file():
-    blank_pdf_filename = settings.BLANK_PDF_FILEPATH
-    if Path(blank_pdf_filename).exists():
+    if Path(blank_pdf_filename := settings.BLANK_PDF_FILEPATH).exists():
         os.remove(blank_pdf_filename)
-    pass
 
 
 def page_with_memo(x: int, y: int, label: str):

--- a/ksicht/pdf.py
+++ b/ksicht/pdf.py
@@ -104,12 +104,11 @@ def concatenate(in_files, out_file, as_duplex=False):
 
         writer.addpages(current_pdf.pages)
 
-        if as_duplex and (num_pages > 1) and (num_pages % 2 == 1):
+        if as_duplex and (num_pages >= 1) and (num_pages % 2 == 1):
             # add blank A4 page
             writer.addpage(get_blank_page())
 
     writer.write(out_file)
-
     return out_file
 
 

--- a/ksicht/pdf.py
+++ b/ksicht/pdf.py
@@ -170,6 +170,6 @@ def prepare_submission_for_export(in_file, label: str):
     # Ensure number of pages is even. Useful for duplex printing.
     num_pages = len(in_pdf.pages)
     if (num_pages % 2 == 1) and num_pages > 1:
-        out_duplex.add_blank_page()
+        out_duplex.add_blank_page(width=PaperSize.A4.width, height=PaperSize.A4.height)
 
     return out_normal, out_duplex

--- a/ksicht/settings.py
+++ b/ksicht/settings.py
@@ -323,3 +323,5 @@ KSICHT_CONTACT_ADDRESS_LINES = [
     "Hlavova 2030",
     "128 43 Praha 2",
 ]
+
+BLANK_PDF_FILEPATH = MEDIA_ROOT + "/" + "blank_page.pdf"

--- a/ksicht/settings.py
+++ b/ksicht/settings.py
@@ -324,4 +324,4 @@ KSICHT_CONTACT_ADDRESS_LINES = [
     "128 43 Praha 2",
 ]
 
-BLANK_PDF_FILEPATH = MEDIA_ROOT + "/" + "blank_page.pdf"
+BLANK_PDF_FILEPATH = os.path.join(MEDIA_ROOT, "blank_page.pdf")


### PR DESCRIPTION
I've improved the way we handle duplex printing by adding blank pages at the time of printing without any slowdown using a temporary file stored in MEDIA root.

I'm not sure why we save each submission file twice (one normal and one duplex), as it only leads to double the space required.
Should probably be fixed in the next code review...

@xaralis Can you please take a look at the edits I made and, if you don't find any problems, publish, so Kuba is able to generate the prints? Thx!